### PR TITLE
Do not use nested namespaces for engines

### DIFF
--- a/lib/stimpack/pack.rb
+++ b/lib/stimpack/pack.rb
@@ -34,7 +34,7 @@ module Stimpack
     private
 
     def create_engine
-      namespace = create_namespace(name)
+      namespace = create_namespace(name.basename)
       stim = Stim.new(self, namespace)
       namespace.const_set("Engine", Class.new(Rails::Engine)).include(stim)
     end

--- a/spec/fixtures/rails-7.0/packs/pants/shorts/package.yml
+++ b/spec/fixtures/rails-7.0/packs/pants/shorts/package.yml
@@ -1,0 +1,2 @@
+metadata:
+  engine: true

--- a/spec/stimpack_spec.rb
+++ b/spec/stimpack_spec.rb
@@ -28,5 +28,9 @@ RSpec.describe Stimpack do
         expect(Rails.application.paths[path].paths).to include(rails_dir.join(Stimpack.config.root, "pants", "shorts", path))
       end
     end
+
+    it "creates engines namespace for engine packs" do
+      expect(defined?(Shorts::Engine)).to eq("constant")
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/rubyatscale/stimpack/issues/26, see issue for more context.

@AlexEvanczuk