### PR TITLE
Bugfix: default path does not have the same format as to_run

### DIFF
--- a/lib/stimpack/integrations/rspec.rb
+++ b/lib/stimpack/integrations/rspec.rb
@@ -6,12 +6,12 @@ module Stimpack
         to_run = ::RSpec.configuration.instance_variable_get(:@files_or_directories_to_run)
         default_path = ::RSpec.configuration.default_path
 
-        if to_run == [default_path]
+        if to_run == [::Rails.root.join(default_path).to_s]
           # This is the default case when you run `rspec`. We want to add all the pack's spec paths
           # to the collection of directories to run.
 
           pack_paths = Packs.all.map do |pack|
-            spec_path = pack.relative_path.join(default_path)
+            spec_path = pack.path.join(default_path)
             spec_path.to_s if spec_path.exist?
           end
 
@@ -22,7 +22,7 @@ module Stimpack
           # end of it.
           #
           # packs/my_pack => packs/my_pack/spec
-          # 
+          #
           # If it doesn't match a pack path, we leave it alone.
 
           to_run.map! do |path|


### PR DESCRIPTION
Using rspec 3.11, I noticed that specs in my packs weren't running. Perhaps something may have changed in Rspec since this integration was committed.

By default, the value of `default_path` is `spec` and the value of `to_run` (when just running the `rspec` command) is `['/full/path/to/spec']`.

After joining `default_path` to `Rails.root` everything seems to be working as expected.