### PR TITLE
Added gem license to the metadata

### DIFF
--- a/lib/packs/rails/version.rb
+++ b/lib/packs/rails/version.rb
@@ -1,5 +1,5 @@
 module Packs
   module Rails
-    VERSION = "0.0.1".freeze
+    VERSION = "0.0.2".freeze
   end
 end

--- a/packs-rails.gemspec
+++ b/packs-rails.gemspec
@@ -8,13 +8,13 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "A Rails helper to package your code."
   spec.description   = "packs-rails establishes and implements a set of conventions for splitting up large monoliths."
-  spec.homepage      = "https://github.com/Gusto/packs-rails"
+  spec.homepage      = "https://github.com/rubyatscale/packs-rails"
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/Gusto/packs-rails"
-  spec.metadata["changelog_uri"] = "https://github.com/Gusto/packs-rails/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/rubyatscale/packs-rails"
+  spec.metadata["changelog_uri"] = "https://github.com/rubyatscale/packs-rails/releases"
 
   spec.files         = Dir["VERSION", "CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "bin/**/*"]
   spec.bindir        = "exe"

--- a/packs-rails.gemspec
+++ b/packs-rails.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "A Rails helper to package your code."
   spec.description   = "packs-rails establishes and implements a set of conventions for splitting up large monoliths."
   spec.homepage      = "https://github.com/Gusto/packs-rails"
+  spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
Currently, repository has a file `LICENSE`, which references MIT license for the library.

In addition, it fixes the links on the Rubygems website:

<img width="384" alt="image" src="https://user-images.githubusercontent.com/10163/214122093-0fca0666-e2c9-473c-a6e9-c2b9fb459114.png">
