### PR TITLE
Added possibility to set custom engine name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ metadata:
   engine: true
 ```
 
+Add `engine_name: ` to your `package.yml` to use a specific, maybe namespaced, engine name instead of the last package folder name.
+```yml
+# packs/my_pack/package.yml
+enforce_dependencies: true
+enforce_privacy: true
+metadata:
+  engine: true
+  engine_name: namespaced/my_pack
+```
+
+The engine is created as `Namespaced::MyPack::Engine` instead of `MyPack::Engine`.
+
 ## Ecosystem and Integrations
 
 ### RSpec Integration

--- a/lib/packs/rails/integrations/rails.rb
+++ b/lib/packs/rails/integrations/rails.rb
@@ -46,7 +46,7 @@ module Packs
         end
 
         def create_engine(pack)
-          name = pack.last_name
+          name = pack.metadata.fetch("engine_name", pack.last_name)
           namespace = create_namespace(name)
           stim = Stim.new(pack, namespace)
           namespace.const_set("Engine", Class.new(::Rails::Engine)).include(stim)

--- a/spec/fixtures/rails-7.0/packs/pants/jeans/app/models/pants/jeans/bootcut.rb
+++ b/spec/fixtures/rails-7.0/packs/pants/jeans/app/models/pants/jeans/bootcut.rb
@@ -1,0 +1,6 @@
+module Pants
+  module Jeans
+    class Bootcut
+    end
+  end
+end

--- a/spec/fixtures/rails-7.0/packs/pants/jeans/package.yml
+++ b/spec/fixtures/rails-7.0/packs/pants/jeans/package.yml
@@ -1,0 +1,3 @@
+metadata:
+  engine: true
+  engine_name: pants/jeans

--- a/spec/packs-rails_spec.rb
+++ b/spec/packs-rails_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe Packs::Rails do
     end
   end
 
+  context 'custom engine name' do
+    it "autoloads classes in autoload paths" do
+      expect(defined?(Pants::Jeans::Bootcut)).to eq("constant")
+    end
+
+    it "adds pack paths to the application" do
+      Packs::Rails.config.paths.each do |path|
+        expect(Rails.application.paths[path].paths).to include(rails_dir.join('packs', "pants", "jeans", path))
+      end
+    end
+
+    it "creates engines namespace for engine packs" do
+      expect(defined?(Pants::Jeans::Engine)).to eq("constant")
+    end
+  end
+
   context 'alternate roots' do
     it "autoloads classes in autoload paths" do
       expect(defined?(Belts::Brown)).to eq("constant")


### PR DESCRIPTION
I've needed a possibility to set a custom engine namespace to create different engines with same package folder name.

Currently the following package structure creates the same engine `Authentication::Engine`

```yml
# packs/backend/authentication/package.ym
metadata:
  engine: true
# packs/frontend/authentication/package.yml
metadata:
  engine: true
```

Now it's possible to set a custom engine name to prevent this issue. 

```yml
# packs/backend/authentication/package.ym
metadata:
  engine: true
  engine_name: backend/authentication
# packs/frontend/authentication/package.yml
metadata:
  engine: true
  engine_name: frontend/authentication
```

This will generate the following engines: `Backend::Authentication::Engine` and `Frontend::Authentication::Engine`

I think it is better to specify the name explicitly instead of generating the package name based on the folder structure.