### PR TITLE
Docs/fix for rails 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,18 @@ From there, you can create a `./packs` folder and structure it using the convent
 If you wish to use a different directory name, eg `components` instead of `packs`, you can customize this by configuring `packs.yml`. See [`packs`](https://github.com/rubyatscale/packs) for more information.
 
 ### Splitting routes
-`packs-rails` allows you to split your application routes for every pack. You just have to create a file describing your routes and then `draw` them in your root `config/routes.rb` file.
+`packs-rails` allows you to split your application routes for every pack. You just have to create a file describing your routes and then `draw` them in your root `config/routes.rb` file (NOTE: the `draw` function is only in Rails 6.1+).
 
 ```ruby
 # packs/my_domain/config/routes/my_domain.rb
-resources :my_resource
+Rails.application.routes.draw do
+  resources :my_resource
+end
 
 # config/routes.rb
-draw(:my_domain)
+Rails.application.routes.draw do
+  draw(:my_domain)
+end
 ```
 
 ### Making your Package an Engine

--- a/lib/packs/rails/integrations/rails.rb
+++ b/lib/packs/rails/integrations/rails.rb
@@ -31,7 +31,7 @@ module Packs
             Packs::Rails.config.paths.each do |path|
               # Prior to Rails 6.1, the "config/routes" app path is nil and was not added until drawable routes feature was implemented
               # https://github.com/rails/rails/pull/37892/files#diff-a785e41df3f87063a8fcffcac726856a25d8eae6d1f9bca2b36989fe88613f8eR62
-              next if path == CONFIG_ROUTES_PATH && Gem::Version.new(::Rails.version) < Gem::Version.new("6.1")
+              next if path == CONFIG_ROUTES_PATH && ::Rails.gem_version < Gem::Version.new("6.1")
 
               @app.paths[path] << pack.relative_path.join(path)
             end

--- a/lib/packs/rails/integrations/rails.rb
+++ b/lib/packs/rails/integrations/rails.rb
@@ -31,7 +31,7 @@ module Packs
             Packs::Rails.config.paths.each do |path|
               # Prior to Rails 6.1, the "config/routes" app path is nil and was not added until drawable routes feature was implemented
               # https://github.com/rails/rails/pull/37892/files#diff-a785e41df3f87063a8fcffcac726856a25d8eae6d1f9bca2b36989fe88613f8eR62
-              next if path == CONFIG_ROUTES_PATH && ::Rails.gem_version < Gem::Version.new("6.1")
+              next if pre_rails_6_1? && path == CONFIG_ROUTES_PATH
 
               @app.paths[path] << pack.relative_path.join(path)
             end
@@ -39,6 +39,11 @@ module Packs
         end
 
         private
+
+        def pre_rails_6_1?
+          return @_pre_rails_6_1 if defined?(@_pre_rails_6_1)
+          @_pre_rails_6_1 = ::Rails.gem_version < Gem::Version.new("6.1")
+        end
 
         def create_namespace(name)
           namespace = ActiveSupport::Inflector.camelize(name)

--- a/lib/packs/rails/integrations/rails.rb
+++ b/lib/packs/rails/integrations/rails.rb
@@ -7,6 +7,8 @@ module Packs
   module Rails
     module Integrations
       class Rails
+        CONFIG_ROUTES_PATH =  "config/routes".freeze
+
         def initialize(app)
           @app = app
 
@@ -27,9 +29,9 @@ module Packs
         def inject_paths
           Packs.all.reject(&:is_gem?).each do |pack|
             Packs::Rails.config.paths.each do |path|
-              # Example case: in rails 6.0, the "config/routes" app path is nil and was not added until
+              # Prior to Rails 6.1, the "config/routes" app path is nil and was not added until drawable routes feature was implemented
               # https://github.com/rails/rails/pull/37892/files#diff-a785e41df3f87063a8fcffcac726856a25d8eae6d1f9bca2b36989fe88613f8eR62
-              next unless @app.paths[path]
+              next if path == CONFIG_ROUTES_PATH && Gem::Version.new(::Rails.version) < Gem::Version.new("6.1")
 
               @app.paths[path] << pack.relative_path.join(path)
             end

--- a/lib/packs/rails/integrations/rails.rb
+++ b/lib/packs/rails/integrations/rails.rb
@@ -27,6 +27,10 @@ module Packs
         def inject_paths
           Packs.all.reject(&:is_gem?).each do |pack|
             Packs::Rails.config.paths.each do |path|
+              # Example case: in rails 6.0, the "config/routes" app path is nil and was not added until
+              # https://github.com/rails/rails/pull/37892/files#diff-a785e41df3f87063a8fcffcac726856a25d8eae6d1f9bca2b36989fe88613f8eR62
+              next unless @app.paths[path]
+
               @app.paths[path] << pack.relative_path.join(path)
             end
           end


### PR DESCRIPTION
Hoping to contribute some small improvements related to rails routing on older rails version 6.0. I ran into a few errors in a rails 6.0.x app, hopefully this saves some pain for others.

https://github.com/rails/rails/blob/6-1-stable/actionpack/CHANGELOG.md and https://github.com/rails/rails/pull/37892/files 

The errors I got were:
* Error that the `@app.paths['config/routes']` is nil. This is "fixed" by skipping that path or any other nil paths when injecting paths
* Error that `draw` function is undefined when calling it in root routes.rb file. I added a note in README about requiring rails 6.1 for this function.

Open to feedback on approach