### PR TITLE
Update routes documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,7 @@ If you wish to use a different directory name, eg `components` instead of `packs
 
 ```ruby
 # packs/my_domain/config/routes/my_domain.rb
-Rails.application.routes.draw do
-  resources :my_resource
-end
+resources :my_resource
 
 # config/routes.rb
 Rails.application.routes.draw do


### PR DESCRIPTION
The routes in `config/routes/*.rb` should not include `Rails.application.routes.draw` block, see [Rails Routing from the Outside In: Breaking Up Very Large Route File into Multiple Small Ones](https://guides.rubyonrails.org/routing.html#breaking-up-very-large-route-file-into-multiple-small-ones)

Corresponding thread in Slack: [#rubyatscale](https://rubymod.slack.com/archives/C052KFB2AQP/p1699900913457459)

Closes https://github.com/rubyatscale/packs-rails/issues/69