### PR TITLE
Fix factory bot integration and add minitest support

### DIFF
--- a/lib/packs/rails/integrations/factory_bot.rb
+++ b/lib/packs/rails/integrations/factory_bot.rb
@@ -9,6 +9,7 @@ module Packs
 
           Packs.all.reject(&:is_gem?).each do |pack|
             app.config.factory_bot.definition_file_paths << pack.relative_path.join("spec/factories").to_s
+            app.config.factory_bot.definition_file_paths << pack.relative_path.join("test/factories").to_s
           end
         end
       end

--- a/lib/packs/rails/railtie.rb
+++ b/lib/packs/rails/railtie.rb
@@ -5,11 +5,14 @@ module Packs
     class Railtie < ::Rails::Railtie
       config.before_configuration do |app|
         Integrations::Rails.new(app)
-        Integrations::FactoryBot.new(app)
-
+        
         # This is not used within packs-rails. Rather, this allows OTHER tools to
         # hook into packs-rails via ActiveSupport hooks.
         ActiveSupport.run_load_hooks(:packs_rails, Packs)
+      end
+      
+      config.after_initialize do |app|
+        Integrations::FactoryBot.new(app)
       end
     end
   end


### PR DESCRIPTION
Fixes #68.

Trying to make the integration work with Minitest I realized the paths were never added because `app.config.respond_to?(:factory_bot)` always returned `false`.

If this is moved in the railtie to a `config.after_initialize` then it works as expected.

I could not write tests since I didn't find any, I am hoping to get advice on how to do these tests here :wink: 
What I did was:

```shell
bin/rails test some_test.rb # it has a binding.pry
# => Rails.application.config.factory_bot.definition_file_paths
[
    [0] "factories",
    [1] "test/factories",
    [2] "spec/factories"
]
```
In that list we should also see every pack path + "spec/factories", but it is not there.

With this fix it will work as expected, and it will also support minitest folder structure `test/factories`.