### PR TITLE
Rename deprecated_references.yml to package_todo.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ app/ # Unpackaged code
 packs/
   my_domain/
     package.yml # See the packwerk docs for more info
-    deprecated_references.yml # See the packwerk docs for more info
+    package_todo.yml # See the packwerk docs for more info
     app/
       public/ # Recommended location for public API
         my_domain.rb # creates the primary namespaces


### PR DESCRIPTION
Since packwerk 2.3.0, deprecated_references.yml has been renamed to package_todo.yml. https://github.com/Shopify/packwerk/pull/242

Therefore, packs-rails needs to be renamed as well to avoid confusion for new packwerk users.