### PR TITLE
Revert to FactoryBot initialization without Rails lifecycle methods (was: Create factories earlier in the lifecycle)

### DIFF
--- a/lib/packs/rails/railtie.rb
+++ b/lib/packs/rails/railtie.rb
@@ -11,7 +11,7 @@ module Packs
         ActiveSupport.run_load_hooks(:packs_rails, Packs)
       end
       
-      config.after_initialize do |app|
+      config.before_initialize do |app|
         Integrations::FactoryBot.new(app)
       end
     end

--- a/lib/packs/rails/railtie.rb
+++ b/lib/packs/rails/railtie.rb
@@ -5,15 +5,13 @@ module Packs
     class Railtie < ::Rails::Railtie
       config.before_configuration do |app|
         Integrations::Rails.new(app)
-        
+        Integrations::FactoryBot.new(app)
+
         # This is not used within packs-rails. Rather, this allows OTHER tools to
         # hook into packs-rails via ActiveSupport hooks.
         ActiveSupport.run_load_hooks(:packs_rails, Packs)
       end
       
-      config.before_initialize do |app|
-        Integrations::FactoryBot.new(app)
-      end
     end
   end
 end


### PR DESCRIPTION
https://github.com/rubyatscale/packs-rails/pull/71 breaks gusto's build. By loading factories earlier in the lifecycle, we see more? full? success.

@matiaseche would you check out if this branch works for your use case?