### PR TITLE
Add spring watch

### DIFF
--- a/lib/packs/rails/railtie.rb
+++ b/lib/packs/rails/railtie.rb
@@ -10,9 +10,7 @@ module Packs
         # This is not used within packs-rails. Rather, this allows OTHER tools to
         # hook into packs-rails via ActiveSupport hooks.
         ActiveSupport.run_load_hooks(:packs_rails, Packs)
-      end
 
-      config.after_initialize do |app|
         if defined?(Spring)
           Packs::Specification::Configuration.fetch.pack_paths.each do |dir|
             Dir["#{dir}/package.yml"].each do |package_yml|

--- a/lib/packs/rails/railtie.rb
+++ b/lib/packs/rails/railtie.rb
@@ -15,8 +15,9 @@ module Packs
       config.after_initialize do |app|
         if defined?(Spring)
           Packs::Specification::Configuration.fetch.pack_paths.each do |dir|
-            file = File.join(dir, "package.yml")
-            Spring.watch(file)
+            Dir["#{dir}/package.yml"].each do |package_yml|
+              Spring.watch(package_yml)
+            end
           end
         end
       end

--- a/lib/packs/rails/railtie.rb
+++ b/lib/packs/rails/railtie.rb
@@ -14,13 +14,9 @@ module Packs
 
       config.after_initialize do |app|
         if defined?(Spring)
-          puts "Hello Db Blasters!"
           Packs::Specification::Configuration.fetch.pack_paths.each do |dir|
-            puts "#{dir}"
-            Dir["#{dir}/package.yml"].each { |f|
-              puts f
-              Spring.watch(f)
-            }
+            file = File.join(dir, "package.yml")
+            Spring.watch(file)
           end
         end
       end

--- a/lib/packs/rails/railtie.rb
+++ b/lib/packs/rails/railtie.rb
@@ -11,7 +11,19 @@ module Packs
         # hook into packs-rails via ActiveSupport hooks.
         ActiveSupport.run_load_hooks(:packs_rails, Packs)
       end
-      
+
+      config.after_initialize do |app|
+        if defined?(Spring)
+          puts "Hello Db Blasters!"
+          Packs::Specification::Configuration.fetch.pack_paths.each do |dir|
+            puts "#{dir}"
+            Dir["#{dir}/package.yml"].each { |f|
+              puts f
+              Spring.watch(f)
+            }
+          end
+        end
+      end
     end
   end
 end

--- a/lib/packs/rails/version.rb
+++ b/lib/packs/rails/version.rb
@@ -1,5 +1,5 @@
 module Packs
   module Rails
-    VERSION = "0.0.5".freeze
+    VERSION = '0.0.6'.freeze
   end
 end

--- a/sorbet/rbi/shims/gems/packs-specification.rbi
+++ b/sorbet/rbi/shims/gems/packs-specification.rbi
@@ -2,7 +2,7 @@
 
 module Packs
   module Specification
-    class Configuration
+    class Configuration < T::Struct
     end
   end
 end

--- a/sorbet/rbi/shims/gems/packs-specification.rbi
+++ b/sorbet/rbi/shims/gems/packs-specification.rbi
@@ -1,0 +1,8 @@
+# typed: strong
+
+module Packs
+  module Specification
+    class Configuration
+    end
+  end
+end

--- a/sorbet/rbi/shims/gems/spring.rbi
+++ b/sorbet/rbi/shims/gems/spring.rbi
@@ -1,0 +1,4 @@
+# typed: strong
+
+module Spring
+end


### PR DESCRIPTION
When a pack moves, we want spring to update the loaded classes so that packwerk prints correct results

<img width="995" alt="Screenshot 2024-02-13 at 13 40 43" src="https://github.com/rubyatscale/packs-rails/assets/119452/80e29f1e-c508-4caa-9af4-83a320fd3030">


Fixes #81 