### PR TITLE
Add more detail to engine documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ end
 ```
 
 ### Making your Package an Engine
-Add `engine: true` to your `package.yml` to make it an actual Rails engine ([read more about what this means here](https://guides.rubyonrails.org/engines.html)):
+You can add `engine: true` to your `package.yml` to make it an actual [Rails engine](https://guides.rubyonrails.org/engines.html).
+
+It implicitly sets up a namespace for your pack and adds namespace isolation.
+
+You can then also use other functionality that engines provide, like per-pack routes, scoped url helpers, or a table name prefix.
+
 ```yml
 # packs/my_pack/package.yml
 enforce_dependencies: true


### PR DESCRIPTION
It previously wasn't clear why you would make something an engine, as this project reimplements part of Rails::Engine's functionality anyway.

The details were stolen from @ngan 's response in https://github.com/rubyatscale/packs-rails/discussions/14.

This still seems a little bit like bending over backwards to me; why isn't every pack an engine by default? Namespace isolation is just one of many engine features and could be off by default.