### PR TITLE
Require Ruby >= 3.3 and update CI Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.2
           - 3.3
           - 3.4
           - 4.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
   NewCops: enable
   Exclude:
     - vendor/bundle/**/**
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.3
 
 Metrics/ParameterLists:
   Enabled: false

--- a/packs-rails.gemspec
+++ b/packs-rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'packs-rails establishes and implements a set of conventions for splitting up large monoliths.'
   spec.homepage      = 'https://github.com/rubyatscale/packs-rails'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.1')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.3')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/rubyatscale/packs-rails'


### PR DESCRIPTION
## Summary

Ruby 3.2 is now EOL. This PR raises the minimum supported Ruby to **3.3** and refreshes CI so the test matrix targets the supported set (**3.3** and **3.4**).

Motivation: resolve Ruby version restrictions from rubyatscale/pack_stats#56, where supporting EOL Ruby forced older/vulnerable transitive dependencies.

## Changes

- **`packs-rails.gemspec`**: `required_ruby_version` raised from `Gem::Requirement.new('>= 3.1')` to `Gem::Requirement.new('>= 3.3')`.
- **`.github/workflows/ci.yml`**: RSpec matrix now tests `3.3`, `3.4`, and `4.0` (dropped `3.2`). The type-check job stays pinned at `3.3` (already supported).
- **`.rubocop.yml`**: `TargetRubyVersion` raised from `2.6` to `3.3`.

## Notes

- No `.ruby-version` / `.tool-versions` files exist in this repo.
- No `bundle install` was run and `Gemfile.lock` is unchanged.
- Latest stable Ruby is 3.4.9; 3.5 is preview-only and not included. The pre-existing `4.0` matrix entry was left intact.
